### PR TITLE
修复文章封面尺寸不对变形

### DIFF
--- a/source/css/_partial/project-card.scss
+++ b/source/css/_partial/project-card.scss
@@ -8,12 +8,12 @@
   color: #333;
   > .imgWrap {
     width: 320px;
-    height: 240px;
     margin-right: 40px;
     background-color: #f8f8f8;
     > img {
       width: 100%;
-      height: 100%;
+      height: auto;
+      display: block;
     }
   }
   > .ctnWrap {


### PR DESCRIPTION
修改文章图片样式为固定宽度，高度自适应，防止图片封面尺寸不合而变形，也兼容了各种尺寸的封面